### PR TITLE
[FEATURE] Adding "merge" conflict resolve strategy

### DIFF
--- a/flagboard-android/build.gradle
+++ b/flagboard-android/build.gradle
@@ -74,7 +74,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.GrinGraz'
                 artifactId = 'flagboard-android'
-                version = '1.2.1'
+                version = '1.3.0'
             }
         }
     }

--- a/flagboard-android/build.gradle
+++ b/flagboard-android/build.gradle
@@ -74,7 +74,7 @@ afterEvaluate {
                 from components.release
                 groupId = 'com.github.GrinGraz'
                 artifactId = 'flagboard-android'
-                version = '1.2.0'
+                version = '1.2.1'
             }
         }
     }

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/Repository.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/Repository.kt
@@ -12,6 +12,7 @@ import org.json.JSONObject
 enum class ConflictStrategy {
     Replace,
     Keep,
+    Merge,
 }
 
 internal class Repository(private val localDataSource: DataSource) {

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/Repository.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/Repository.kt
@@ -26,6 +26,9 @@ internal class Repository(private val localDataSource: DataSource) {
                 localDataSource.clear()
                 localDataSource.save(featureFlag)
             }
+            ConflictStrategy.Merge -> {
+                localDataSource.save(featureFlag)
+            }
         }
     }
 


### PR DESCRIPTION
## 🆕  **Proposed changes**

### 📖 Context

This PR addresses the inability to apply partial flag updates without overwriting the entire configuration. It introduces the Merge strategy to solve this, enabling a new set of data to be merged with the existing data stored on the device.

### ✍️ What has been done

- [X] ✨ Add to enum class new `merge` 
- [X] ✨ Add case for new `merge` param using direct a `save` function

## 🚩 Conflict Strategies Docs

When loading flags, you can specify a `ConflictStrategy` to determine how new data should interact with any data that is already stored on the device.

### `ConflictStrategy.Replace`
Deletes all previously stored flags and then saves the new set.
* **Use case:** Ideal for a full refresh or the initial app launch to ensure a clean state.

### `ConflictStrategy.Keep`
Saves the new flags *only if* there are no flags currently stored. If any data already exists, this operation does nothing.
* **Use case:** Useful for a one-time setup to avoid accidentally overwriting user-modified or cached flags on subsequent launches also can use like initial state

### `ConflictStrategy.Merge`
Fuses the incoming set of flags with the data that is already stored.
* It **updates** the values of existing keys.
* It **adds** new keys that are not in the current set.
* It **keeps** old keys that are not present in the incoming set.
* **Use case:** Perfect for applying partial updates from a remote source (like Firebase Remote Config) without losing the full configuration.

---

### Example: `Replace` vs. `Merge`

To understand the difference, lets consider a practical example 🤖 .

Imagine you have these flags already stored on the device:
```json
{
  "feature_A": true,
  "feature_B": 100
}
```

Now, you receive a partial update from your server with the following flags:

```json
{
  "feature_B": 500,
  "feature_C": false
}
```

###  **Using ConflictStrategy.`Replace`**
This strategy first deletes all stored data and then saves the incoming flags.

The final stored data will be:

```json
{
  "feature_B": 500,
  "feature_C": false
}
```

(Notice: feature_A was deleted because it wasn't in the new set).

### **Using ConflictStrategy.`Merge`**
This strategy fuses the new data with the existing data.

The final stored data will be:

```json
{
  "feature_A": true,
  "feature_B": 500,
  "feature_C": false
}
```

(Notice: feature_A was kept, feature_B was updated, and feature_C was added).
