### PR TITLE
feat: runtime opt-in between Local and Firebase Remote Config sources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -54,6 +55,9 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.activity:activity-compose:1.3.1'
     implementation project(path: ':flagboard-android')
+    implementation platform('com.google.firebase:firebase-bom:32.7.0')
+    implementation 'com.google.firebase:firebase-config-ktx'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/cl/gringraz/flagboard/MainActivity.kt
+++ b/app/src/main/java/cl/gringraz/flagboard/MainActivity.kt
@@ -15,7 +15,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import cl.gringraz.flagboard.ui.theme.FlagboardTheme
 import cl.gringraz.flagboard_android.Flagboard
+import cl.gringraz.flagboard_android.FlagboardSource
 import cl.gringraz.flagboard_android.data.ConflictStrategy
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 
 
 class MainActivity : ComponentActivity() {
@@ -35,7 +38,12 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun Dashboard() {
     val context = LocalContext.current
-    Flagboard.init(context)
+    // To enable runtime source switching in the Flagboard debug UI, provide a
+    // pre-configured FirebaseRemoteConfig instance. Without it, only local flags are shown.
+    val rc = FirebaseRemoteConfig.getInstance().apply {
+        setConfigSettingsAsync(remoteConfigSettings { minimumFetchIntervalInSeconds = 0 })
+    }
+    Flagboard.init(context, FlagboardSource.Firebase(rc))
 
     val map = mapOf(
         "Boolean flag1" to true,

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'com.android.application' version '7.0.2' apply false
     id 'com.android.library' version '7.0.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
+    id 'com.google.gms.google-services' version '4.4.0' apply false
 }
 
 tasks.register('clean', Delete) {

--- a/flagboard-android/build.gradle
+++ b/flagboard-android/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     implementation "androidx.compose.runtime:runtime:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
+    compileOnly 'com.google.firebase:firebase-config-ktx:21.4.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/FBDataState.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/FBDataState.kt
@@ -3,4 +3,5 @@ package cl.gringraz.flagboard_android
 enum class FBDataState {
     FF_LOADED,
     FF_NOT_LOADED,
+    FF_LOADING,
 }

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/Flagboard.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/Flagboard.kt
@@ -18,8 +18,9 @@ object Flagboard {
      * @see [ConflictStrategy]
      */
     @JvmStatic
-    fun init(@NonNull context: Context): Flagboard {
-        FlagboardInternal.init(context = context)
+    @JvmOverloads
+    fun init(@NonNull context: Context, source: FlagboardSource = FlagboardSource.Local): Flagboard {
+        FlagboardInternal.init(context = context, source = source)
         return this
     }
 

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/FlagboardSource.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/FlagboardSource.kt
@@ -1,0 +1,11 @@
+package cl.gringraz.flagboard_android
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+
+sealed class FlagboardSource {
+    object Local : FlagboardSource()
+    data class Firebase(
+        val remoteConfig: FirebaseRemoteConfig,
+        val cacheExpirationSeconds: Long = 3600L,
+    ) : FlagboardSource()
+}

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/RemoteSource.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/RemoteSource.kt
@@ -1,0 +1,33 @@
+package cl.gringraz.flagboard_android.data
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+internal class RemoteSource(
+    private val remoteConfig: FirebaseRemoteConfig,
+    private val cacheExpirationSeconds: Long,
+) {
+    suspend fun fetchAndActivate(): Map<String, Any> =
+        suspendCancellableCoroutine { continuation ->
+            remoteConfig.fetch(cacheExpirationSeconds)
+                .addOnSuccessListener {
+                    remoteConfig.activate().addOnCompleteListener {
+                        val result = remoteConfig.all.mapValues { (_, v) ->
+                            coerceRcValue(v.asString())
+                        }
+                        continuation.resume(result)
+                    }
+                }
+                .addOnFailureListener { continuation.resumeWithException(it) }
+        }
+
+    private fun coerceRcValue(raw: String): Any {
+        if (raw.equals("true", ignoreCase = true)) return true
+        if (raw.equals("false", ignoreCase = true)) return false
+        raw.toLongOrNull()?.let { return it }
+        raw.toDoubleOrNull()?.let { return it }
+        return raw
+    }
+}

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/Repository.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/data/Repository.kt
@@ -83,6 +83,11 @@ internal class Repository(private val localDataSource: DataSource) {
         else                      -> FeatureFlag.StringFlag(param = param)
     }
 
+    internal fun replaceAll(flags: Map<String, Any>) {
+        localDataSource.clear()
+        localDataSource.save(flags)
+    }
+
     fun save(key: String, value: Any) = localDataSource.save(key, value)
 
     fun clear() = localDataSource.clear()

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/di/FlagboardContainer.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/di/FlagboardContainer.kt
@@ -1,11 +1,23 @@
 package cl.gringraz.flagboard_android.di
 
 import android.content.Context
+import cl.gringraz.flagboard_android.FlagboardSource
 import cl.gringraz.flagboard_android.data.LocalDataSource
+import cl.gringraz.flagboard_android.data.RemoteSource
 import cl.gringraz.flagboard_android.data.Repository
 
-internal class FlagboardContainer(context: Context) {
-    private val sharedPreferences by lazy { context.getSharedPreferences("flagboard", Context.MODE_PRIVATE) }
+internal class FlagboardContainer(context: Context, source: FlagboardSource = FlagboardSource.Local) {
+    private val sharedPreferences by lazy {
+        context.getSharedPreferences("flagboard", Context.MODE_PRIVATE)
+    }
     private val localDataSource by lazy { LocalDataSource(sharedPreferences) }
+
+    internal val remoteSource: RemoteSource? by lazy {
+        when (source) {
+            is FlagboardSource.Firebase -> RemoteSource(source.remoteConfig, source.cacheExpirationSeconds)
+            is FlagboardSource.Local    -> null
+        }
+    }
+
     internal val repository by lazy { Repository(localDataSource) }
 }

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/presentation/FlagboardInternal.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/presentation/FlagboardInternal.kt
@@ -3,9 +3,11 @@ package cl.gringraz.flagboard_android.presentation
 import android.content.Context
 import cl.gringraz.flagboard_android.FBDataState
 import cl.gringraz.flagboard_android.FBState
+import cl.gringraz.flagboard_android.FlagboardSource
 import cl.gringraz.flagboard_android.data.ConflictStrategy
-import cl.gringraz.flagboard_android.data.models.FBDataError
+import cl.gringraz.flagboard_android.data.RemoteSource
 import cl.gringraz.flagboard_android.data.Repository
+import cl.gringraz.flagboard_android.data.models.FBDataError
 import cl.gringraz.flagboard_android.data.models.FeatureFlag
 import cl.gringraz.flagboard_android.di.FlagboardContainer
 import cl.gringraz.flagboard_android.ui.FlagboardActivity
@@ -17,40 +19,71 @@ internal object FlagboardInternal {
     private var state: FBState = FBState.Unknown
     private lateinit var repository: Repository
     private lateinit var container: FlagboardContainer
+    private var remoteSource: RemoteSource? = null
+    internal var configuredSource: FlagboardSource = FlagboardSource.Local
+        private set
+    private var lastLocalFlags: Map<String, Any> = emptyMap()
     private val defaultInt by lazy { -1 }
     private val defaultString by lazy { "" }
 
+    internal val isRemoteConfigured: Boolean get() = remoteSource != null
+
+    internal var currentSource: FlagboardSource = FlagboardSource.Local
+        private set
+
     internal fun getState() = state
 
-    internal fun init(context: Context) {
+    internal fun init(context: Context, source: FlagboardSource = FlagboardSource.Local) {
         log(initializingStateMessage)
-        container = FlagboardContainer(context)
+        container = FlagboardContainer(context, source)
         repository = container.repository
+        remoteSource = container.remoteSource
+        configuredSource = source
+        currentSource = FlagboardSource.Local
         state = FBState.Initialized(FBDataState.FF_NOT_LOADED)
         log(initializedStateMessage)
     }
 
     internal fun open(context: Context) = when (val safeState = state) {
         is FBState.Initialized -> {
-            if (safeState.ffLoaded == FBDataState.FF_LOADED) {
-                FlagboardActivity.openFlagBoard(context)
-            } else {
+            if (safeState.ffLoaded == FBDataState.FF_NOT_LOADED) {
                 log(initializedWithoutDataStateMessage)
+            } else {
+                FlagboardActivity.openFlagBoard(context)
             }
         }
-        is FBState.Unknown     -> log(unknownStateMessage)
+        is FBState.Unknown -> log(unknownStateMessage)
     }
-
 
     internal fun loadFlags(featureFlagsMap: Map<String, Any>, conflictStrategy: ConflictStrategy) {
         when (state) {
             is FBState.Initialized -> {
+                lastLocalFlags = featureFlagsMap
                 repository.save(featureFlagsMap, conflictStrategy)
                 state = FBState.Initialized(FBDataState.FF_LOADED)
                 log("$flagsLoadedAndStrategyMessage ${conflictStrategy.name}.")
             }
             is FBState.Unknown -> log(unknownStateMessage)
         }
+    }
+
+    internal suspend fun activateRemoteSource() {
+        val remote = remoteSource ?: run { log(remoteNotConfiguredMessage); return }
+        state = FBState.Initialized(FBDataState.FF_LOADING)
+        log(remoteLoadStartedMessage)
+        val remoteFlags = remote.fetchAndActivate()
+        repository.replaceAll(remoteFlags)
+        currentSource = configuredSource
+        state = FBState.Initialized(FBDataState.FF_LOADED)
+        log(remoteLoadSuccessMessage)
+    }
+
+    internal fun activateLocalSource() {
+        if (lastLocalFlags.isEmpty()) { log("No local flags to restore."); return }
+        repository.replaceAll(lastLocalFlags)
+        currentSource = FlagboardSource.Local
+        state = FBState.Initialized(FBDataState.FF_LOADED)
+        log("Local source activated.")
     }
 
     internal fun getFlags(): List<FeatureFlag> {
@@ -112,6 +145,8 @@ internal object FlagboardInternal {
 
     internal fun reset() {
         repository.clear()
+        lastLocalFlags = emptyMap()
+        currentSource = FlagboardSource.Local
         state = FBState.Initialized(FBDataState.FF_NOT_LOADED)
     }
 

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/ui/FlagboardActivity.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/ui/FlagboardActivity.kt
@@ -11,10 +11,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.core.content.ContextCompat
+import cl.gringraz.flagboard_android.FlagboardSource
+import cl.gringraz.flagboard_android.presentation.FlagboardInternal
 import cl.gringraz.flagboard_android.ui.theme.FlagboardTheme
+import cl.gringraz.flagboard_android.util.log
+import kotlinx.coroutines.launch
 
 internal class FlagboardActivity : ComponentActivity() {
 
@@ -22,16 +27,45 @@ internal class FlagboardActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val textState = remember { mutableStateOf(TextFieldValue("")) }
+            val activeSource = remember { mutableStateOf(FlagboardInternal.currentSource) }
+            val isLoading = remember { mutableStateOf(false) }
+            val flags = remember { mutableStateOf(FlagboardInternal.getFlags()) }
+            val coroutineScope = rememberCoroutineScope()
+
+            fun switchSource(source: FlagboardSource) {
+                coroutineScope.launch {
+                    isLoading.value = true
+                    try {
+                        when (source) {
+                            is FlagboardSource.Firebase -> FlagboardInternal.activateRemoteSource()
+                            is FlagboardSource.Local    -> FlagboardInternal.activateLocalSource()
+                        }
+                        activeSource.value = source
+                        flags.value = FlagboardInternal.getFlags()
+                    } catch (e: Exception) {
+                        log("Source switch failed: ${e.message}")
+                    } finally {
+                        isLoading.value = false
+                    }
+                }
+            }
+
             FlagboardTheme {
                 Scaffold(
-                    topBar = { 
-                        AppTopBar(context = this)
-                             },
+                    topBar = {
+                        AppTopBar(
+                            context = this,
+                            showRemoteTab = FlagboardInternal.isRemoteConfigured,
+                            activeSource = activeSource.value,
+                            isLoading = isLoading.value,
+                            onSourceSelected = ::switchSource,
+                        )
+                    },
                 ) {
                     Box(modifier = Modifier.padding(it)) {
                         Column {
                             SearchView(textState)
-                            FlagList(textState)
+                            FlagList(textState = textState, flags = flags.value)
                         }
                     }
                 }

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/ui/composables.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/ui/composables.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,10 +12,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Switch
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
@@ -37,6 +41,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import cl.gringraz.flagboard_android.FlagboardSource
 import cl.gringraz.flagboard_android.R
 import cl.gringraz.flagboard_android.data.models.FeatureFlag
 import cl.gringraz.flagboard_android.data.models.Param
@@ -45,21 +50,65 @@ import org.json.JSONObject
 import java.util.Locale
 
 @Composable
-internal fun AppTopBar(context: Context) {
-    TopAppBar(
-        backgroundColor = Color.Black,
-        contentColor = Color.White,
-        title = { Text(text = "Flagboard") },
-        navigationIcon = {
-            IconButton(onClick = { (context as ComponentActivity).finish() }) {
-                Icon(Icons.Filled.ArrowBack, contentDescription = null)
+internal fun AppTopBar(
+    context: Context,
+    showRemoteTab: Boolean,
+    activeSource: FlagboardSource,
+    isLoading: Boolean,
+    onSourceSelected: (FlagboardSource) -> Unit,
+) {
+    val selectedTabIndex = if (activeSource is FlagboardSource.Firebase) 1 else 0
+
+    Column {
+        TopAppBar(
+            backgroundColor = Color.Black,
+            contentColor = Color.White,
+            title = { Text(text = "Flagboard") },
+            navigationIcon = {
+                IconButton(onClick = { (context as ComponentActivity).finish() }) {
+                    Icon(Icons.Filled.ArrowBack, contentDescription = null)
+                }
+            },
+            actions = {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        color = Color.White,
+                        strokeWidth = 2.dp,
+                        modifier = Modifier
+                            .size(24.dp)
+                            .padding(end = 8.dp),
+                    )
+                }
+            }
+        )
+        if (showRemoteTab) {
+            TabRow(
+                selectedTabIndex = selectedTabIndex,
+                backgroundColor = Color.Black,
+                contentColor = Color.White,
+            ) {
+                Tab(
+                    selected = selectedTabIndex == 0,
+                    onClick = { onSourceSelected(FlagboardSource.Local) },
+                    text = { Text("Local") },
+                )
+                Tab(
+                    selected = selectedTabIndex == 1,
+                    onClick = {
+                        val firebaseSource = FlagboardInternal.currentSource
+                            .takeIf { it is FlagboardSource.Firebase }
+                            ?: FlagboardInternal.configuredSource
+                        onSourceSelected(firebaseSource)
+                    },
+                    text = { Text("Firebase RC") },
+                )
             }
         }
-    )
+    }
 }
 
 @Composable
-internal fun FlagList(textState: MutableState<TextFieldValue>) {
+internal fun FlagList(textState: MutableState<TextFieldValue>, flags: List<FeatureFlag>) {
     val context = LocalContext.current
     var filteredList: MutableList<FeatureFlag>
     LazyColumn(
@@ -67,10 +116,9 @@ internal fun FlagList(textState: MutableState<TextFieldValue>) {
     ) {
         val searchedText = textState.value.text
         filteredList = if (searchedText.isEmpty()) {
-            FlagboardInternal.getFlags().toMutableList()
+            flags.toMutableList()
         } else {
             val resultList = mutableListOf<FeatureFlag>()
-            val flags = FlagboardInternal.getFlags().toMutableList()
             for (flag in flags) {
                 when (flag) {
                     is FeatureFlag.BooleanFlag -> {
@@ -136,8 +184,6 @@ internal fun ItemRow(modifier: Modifier = Modifier, param: Param<*>, onRowClick:
     }
 }
 
-
-
 @Composable
 fun SearchView(state: MutableState<TextFieldValue>) {
     TextField(
@@ -161,8 +207,7 @@ fun SearchView(state: MutableState<TextFieldValue>) {
             if (state.value != TextFieldValue("")) {
                 IconButton(
                     onClick = {
-                        state.value =
-                            TextFieldValue("") // Remove text from TextField when you press the 'X' icon
+                        state.value = TextFieldValue("")
                     }
                 ) {
                     Icon(
@@ -176,7 +221,7 @@ fun SearchView(state: MutableState<TextFieldValue>) {
             }
         },
         singleLine = true,
-        shape = RectangleShape, // The TextFiled has rounded corners top left and right by default
+        shape = RectangleShape,
         colors = TextFieldDefaults.textFieldColors(
             textColor = Color.White,
             cursorColor = Color.White,

--- a/flagboard-android/src/main/java/cl/gringraz/flagboard_android/util/LogHelper.kt
+++ b/flagboard-android/src/main/java/cl/gringraz/flagboard_android/util/LogHelper.kt
@@ -16,3 +16,7 @@ internal val tryToSaveUnsupportedTypeMsg by lazy { "try to save an unsupported d
 internal val failedInitializationMessage by lazy { "initialization failed." }
 internal val flagsLoadedAndStrategyMessage by lazy { "feature flag loading strategy is: " }
 internal val initializedWithoutDataStateMessage by lazy { "has not feature flags loaded. First call the FlagBoard.loadFlags(@NonNull featureFlagsMap: Map<String, Any>) function." }
+internal val remoteLoadStartedMessage by lazy { "remote flag fetch started." }
+internal val remoteLoadSuccessMessage by lazy { "remote flags loaded and cached." }
+internal val remoteLoadFailureMessage by lazy { "remote flag fetch failed." }
+internal val remoteNotConfiguredMessage by lazy { "remote source not configured. Call Flagboard.init with FlagboardSource.Firebase." }


### PR DESCRIPTION
## Summary

- Adds `FlagboardSource` sealed class (`Local` / `Firebase`) so the host app can register a pre-configured `FirebaseRemoteConfig` instance at init time — existing `Flagboard.init(context)` calls continue to work unchanged thanks to `@JvmOverloads`
- `FlagboardActivity` now shows **`[Local | Firebase RC]`** tabs in the top bar whenever a Firebase source is configured; tapping a tab fetches/restores flags and recomposes the flag list reactively with a spinner during the fetch
- Switching sources affects both the debug UI **and** the runtime getters (`getBoolean`, `getString`, etc.) — SharedPreferences content is swapped on each switch, so no getter code changes were needed
- Switching back to **Local** restores the exact map passed to `loadFlags()`, cached in memory by `FlagboardInternal.lastLocalFlags`
- Firebase RC is `compileOnly` in the library module — consumers that use only `FlagboardSource.Local` incur zero transitive Firebase dependency

## What changed

| File | Change |
|------|--------|
| `FlagboardSource.kt` | **New** — sealed class with `Local` and `Firebase(remoteConfig, cacheExpirationSeconds)` |
| `RemoteSource.kt` | **New** — suspending Firebase RC fetch with Boolean/Long/Double/String coercion |
| `FBDataState.kt` | Add `FF_LOADING` state for in-progress fetch |
| `FlagboardContainer.kt` | Accept `FlagboardSource`, expose `RemoteSource?` |
| `Repository.kt` | Add `replaceAll()` for source-switch writes |
| `FlagboardInternal.kt` | `init(source)`, `activateRemoteSource()` (suspend), `activateLocalSource()`, `lastLocalFlags` cache |
| `Flagboard.kt` | `init()` accepts optional `FlagboardSource` |
| `FlagboardActivity.kt` + `composables.kt` | Source tabs in top bar, reactive flag list, loading spinner |
| `flagboard-android/build.gradle` | Add `kotlinx-coroutines-android` + `compileOnly firebase-config-ktx` |
| `app/build.gradle` + root `build.gradle` | Firebase BOM + Google services for demo app |

## Test plan

- [ ] `./gradlew :flagboard-android:assembleDebug` — library builds, Firebase RC not bundled in AAR
- [ ] `Flagboard.init(context)` (no source) → `open()` shows flag list with **no tabs** (backward-compatible)
- [ ] `Flagboard.init(context, FlagboardSource.Firebase(rc))` → `open()` shows `[Local | Firebase RC]` tabs
- [ ] Tapping **Firebase RC** → spinner → flags update to RC values → getters return RC values
- [ ] Tapping **Local** → flags restore to original `loadFlags(map)` values
- [ ] Network failure: spinner disappears, error logged, list unchanged
- [ ] Demo app builds with `google-services.json` in `app/`

> **Note:** The demo app requires a `google-services.json` in `app/`. The library compiles without it.